### PR TITLE
Creating duplicate logs in pipeline.

### DIFF
--- a/ai/settings.py
+++ b/ai/settings.py
@@ -58,7 +58,7 @@ try:
     logging.info("Logging Set To: " + log_level_str)
 
     if LOG_LEVEL != logging.WARNING:
-        set_log_level(LOG_LEVEL)
+#        set_log_level(LOG_LEVEL)
 except Exception as ex:
     template = 'Error: {0} Problem reading Logging Level string from environment variables. Logging set to WARNING LEVEL. Arguments: \n{1!r}'
     message = template.format(type(ex).__name__, ex.args)


### PR DESCRIPTION
Do not set logs in custom function.  Use logger locally or use print. But do not change root logger.